### PR TITLE
Add validation function for listen channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,10 +45,23 @@ handler.Handle("open", func(msg []byte, authToken string) *Message {
 Server push
 -----------
 
-The server can push commands and data to the clients using channels for which the clients have to register as listeners. The server may also push commands and data to specific clients whenever necessary using their session ID.
+The server can push commands and data to the clients using channels for which the clients have to register as listeners.
+
+Channels can have validation functions attached on setup to restrict which clients will be allowed to register as listeners.
+These validation functions will be called whenever a client tries to register as a listener with the auth token that client submitted when connecting.
+A return value of `nil` will be considered a successful validation while any error will be considered a validation failure and therefore prevent the client from registering as a listener. The errors will not be relayed to the client to improve security. Instead a generic error message will be sent.
+
+The server may also push commands and data to specific clients whenever necessary using their session ID.
 
 ```go
-handler.RegisterListenChannel("test")
+handler.RegisterListenChannel("test", nil) // Anyone can register as a listener
+
+handler.RegisterListenChannel("restricted", func(t string) error {
+	if t != "valid" {
+		return errors.New("Invalid token")
+	}
+	return nil
+})
 
 handler.WriteToChannel("test", NewMessage("thanks", []byte("Thank you for listening!")))
 

--- a/handler.go
+++ b/handler.go
@@ -29,8 +29,8 @@ func (h *Handler) handlerRoutine(conn *ws.Conn, sessionid uuid.UUID, token strin
 		msg := parseMessage(rawMsg)
 		if bytes.Equal(msg.command, []byte("listen")) {
 			if c, ok := h.channels[string(msg.content)]; ok && c.validationFunc != nil {
-				if err := c.validationFunc(token); err != nil {
-					if h.writeToClient(sessionid, cmdWebSocket, []byte(err.Error())) != nil {
+				if c.validationFunc(token) != nil {
+					if h.writeToClient(sessionid, cmdWebSocket, []byte("not authorized")) != nil {
 						break
 					}
 					continue

--- a/listener.go
+++ b/listener.go
@@ -7,13 +7,14 @@ import (
 )
 
 // RegisterListenChannel registers a channel for writing to clients listening on it
-func (h *Handler) RegisterListenChannel(name string) error {
+func (h *Handler) RegisterListenChannel(name string, validationFunc func(string) error) error {
 	if _, ok := h.channels[name]; ok {
 		return errors.New("channel already exists")
 	}
 	h.channels[name] = &channel{
 		make(chan *Message, 8),
 		make([]uuid.UUID, 0),
+		validationFunc,
 	}
 	go h.channelRoutine(name)
 	return nil

--- a/listener.go
+++ b/listener.go
@@ -6,7 +6,10 @@ import (
 	"github.com/fossoreslp/go-uuid-v4"
 )
 
-// RegisterListenChannel registers a channel for writing to clients listening on it
+// RegisterListenChannel registers a channel for writing to clients listening on it.
+// It takes the channel name as a string and a validation function taking a string and returning an error as arguments.
+// You may use nil instead of a validation function in case no validation is required.
+// When using a validation function, a return value of nil is considered as validation successful while an error means validation failed.
 func (h *Handler) RegisterListenChannel(name string, validationFunc func(string) error) error {
 	if _, ok := h.channels[name]; ok {
 		return errors.New("channel already exists")

--- a/listener_test.go
+++ b/listener_test.go
@@ -9,7 +9,8 @@ import (
 func TestHandler_RegisterListenChannel(t *testing.T) {
 	handler := NewHandler()
 	type args struct {
-		name string
+		name         string
+		validateFunc func(string) error
 	}
 	tests := []struct {
 		name    string
@@ -17,12 +18,12 @@ func TestHandler_RegisterListenChannel(t *testing.T) {
 		args    args
 		wantErr bool
 	}{
-		{"Normal", handler, args{"test"}, false},
-		{"AlreadyExists", handler, args{"test"}, true},
+		{"Normal", handler, args{"test", nil}, false},
+		{"AlreadyExists", handler, args{"test", nil}, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := tt.h.RegisterListenChannel(tt.args.name); (err != nil) != tt.wantErr {
+			if err := tt.h.RegisterListenChannel(tt.args.name, tt.args.validateFunc); (err != nil) != tt.wantErr {
 				t.Errorf("Handler.RegisterListenChannel() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
@@ -32,7 +33,7 @@ func TestHandler_RegisterListenChannel(t *testing.T) {
 func TestHandler_registerAsListener(t *testing.T) {
 	handler := NewHandler()
 	id := uuid.UUID{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0}
-	if err := handler.RegisterListenChannel("test"); err != nil {
+	if err := handler.RegisterListenChannel("test", nil); err != nil {
 		t.Fatalf("Could not register listen channel: %s", err.Error())
 	}
 	type args struct {
@@ -67,7 +68,7 @@ func TestHandler_unregisterAsListener(t *testing.T) {
 	handler := NewHandler()
 	id := uuid.UUID{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0}
 	altID := uuid.UUID{0xF, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0}
-	if err := handler.RegisterListenChannel("test"); err != nil {
+	if err := handler.RegisterListenChannel("test", nil); err != nil {
 		t.Fatalf("Could not register listen channel: %s", err.Error())
 	}
 	// Add ID as only ID in list
@@ -119,18 +120,18 @@ func TestHandler_unregisterAsListener(t *testing.T) {
 func TestHandler_unregisterListener(t *testing.T) {
 	handler := NewHandler()
 	id := uuid.UUID{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0}
-	if err := handler.RegisterListenChannel("test1"); err != nil {
+	if err := handler.RegisterListenChannel("test1", nil); err != nil {
 		t.Fatalf("Could not register listen channel: %s", err.Error())
 	}
 	handler.channels["test1"].listeners = append(handler.channels["test1"].listeners, id)
-	if err := handler.RegisterListenChannel("test2"); err != nil {
+	if err := handler.RegisterListenChannel("test2", nil); err != nil {
 		t.Fatalf("Could not register listen channel: %s", err.Error())
 	}
-	if err := handler.RegisterListenChannel("test3"); err != nil {
+	if err := handler.RegisterListenChannel("test3", nil); err != nil {
 		t.Fatalf("Could not register listen channel: %s", err.Error())
 	}
 	handler.channels["test3"].listeners = append(handler.channels["test3"].listeners, id)
-	if err := handler.RegisterListenChannel("test4"); err != nil {
+	if err := handler.RegisterListenChannel("test4", nil); err != nil {
 		t.Fatalf("Could not register listen channel: %s", err.Error())
 	}
 	handler.unregisterListener(id)

--- a/types.go
+++ b/types.go
@@ -14,10 +14,11 @@ var cmdWebSocket = []byte("websocket")
 // Handle functions take the message as a byte slice and the auth token as a string and may return a message that will be submitted to the client or nil if no response is necessary.
 type HandleFunc func([]byte, string) *Message
 
-// channel stores a channel used to buffer the messsages as well as a slice containing the session ids of all listeners.
+// channel stores a channel used to buffer the messsages as well as a slice containing the session ids of all listeners. It also may contains a validation function in case not everyone should be able to listen on the channel.
 type channel struct {
-	send      chan *Message
-	listeners []uuid.UUID
+	send           chan *Message
+	listeners      []uuid.UUID
+	validationFunc func(string) error
 }
 
 /*Handler is the base type of a websocket endpoint.

--- a/types.go
+++ b/types.go
@@ -14,7 +14,7 @@ var cmdWebSocket = []byte("websocket")
 // Handle functions take the message as a byte slice and the auth token as a string and may return a message that will be submitted to the client or nil if no response is necessary.
 type HandleFunc func([]byte, string) *Message
 
-// channel stores a channel used to buffer the messsages as well as a slice containing the session ids of all listeners. It also may contains a validation function in case not everyone should be able to listen on the channel.
+// channel stores a channel used to buffer the messsages as well as a slice containing the session ids of all listeners. It also may contain a validation function in case not everyone should be able to listen on the channel.
 type channel struct {
 	send           chan *Message
 	listeners      []uuid.UUID

--- a/write_test.go
+++ b/write_test.go
@@ -78,7 +78,7 @@ func TestHandler_channelRoutine(t *testing.T) {
 		t.Fatalf("Failed to generate random ID for testing: %s", err.Error())
 	}
 	h.writeChannels[sessionID] = make(chan []byte, 8)
-	h.channels["test"] = &channel{make(chan *Message, 2), []uuid.UUID{sessionID, randomID}}
+	h.channels["test"] = &channel{make(chan *Message, 2), []uuid.UUID{sessionID, randomID}, nil}
 	go h.channelRoutine("test")
 	h.channels["test"].send <- &Message{[]byte("cmd"), []byte("content")}
 	msg := <-h.writeChannels[sessionID]
@@ -89,7 +89,7 @@ func TestHandler_channelRoutine(t *testing.T) {
 
 func TestHandler_WriteToChannel(t *testing.T) {
 	h := NewHandler()
-	h.channels["test"] = &channel{make(chan *Message, 8), []uuid.UUID{}}
+	h.channels["test"] = &channel{make(chan *Message, 8), []uuid.UUID{}, nil}
 	type args struct {
 		channel string
 		msg     *Message


### PR DESCRIPTION
Adding a function that is called before adding a client as a listener and may return an error to prevent the client being registered as a listener.
This makes it possible to ensure only specific clients can listen on a channel by validating the token submitted to the validation function.
Channels are therefore now safe for sensitive data when using WSS (WebSocket over TLS).